### PR TITLE
Improve third-person question detection with regex

### DIFF
--- a/backend/question_analyzer.py
+++ b/backend/question_analyzer.py
@@ -157,28 +157,35 @@ class TraditionalHoraryQuestionAnalyzer:
     def _detect_third_person_question(self, question: str) -> Dict[str, Any]:
         """Detect if question is about someone else requiring house turning"""
         
+        import re
+
         # Strong 3rd person indicators
         third_person_patterns = [
             # Direct pronouns
-            "will he ", "will she ", "will they ", "did he ", "did she ", "has he ", "has she ",
-            "does he ", "does she ", "can he ", "can she ", "should he ", "should she ",
-            # Possessives  
-            " his ", " her ", " their ",
+            r"\bwill he\b", r"\bwill she\b", r"\bwill they\b",
+            r"\bdid he\b", r"\bdid she\b",
+            r"\bhas he\b", r"\bhas she\b",
+            r"\bdoes he\b", r"\bdoes she\b",
+            r"\bcan he\b", r"\bcan she\b",
+            r"\bshould he\b", r"\bshould she\b",
+            r"\bis he\b", r"\bis she\b", r"\bis they\b",
+            # Possessives
+            r"\bhis\b", r"\bher\b", r"\btheir\b",
             # Specific relationships
-            "the student", "my student", "the teacher", "my friend", "my partner", "my husband", 
-            "my wife", "my child", "my son", "my daughter", "the patient", "my client",
+            r"the student", r"my student", r"the teacher", r"my friend", r"my partner", r"my husband",
+            r"my wife", r"my child", r"my son", r"my daughter", r"the patient", r"my client",
             # Question about someone else
-            "asked by his", "asked by her", "asked by the"
+            r"asked by his", r"asked by her", r"asked by the",
         ]
-        
+
         # Context clues that suggest 3rd person
         for pattern in third_person_patterns:
-            if pattern in question:
+            if re.search(pattern, question):
                 return {
                     "is_third_person": True,
                     "subject_house": 7,  # The other person = 7th house
                     "turn_houses": True,
-                    "pattern_matched": pattern.strip()
+                    "pattern_matched": pattern.strip(),
                 }
         
         # Educational context: teacher asking about student

--- a/backend/tests/test_is_she_pregnant.py
+++ b/backend/tests/test_is_she_pregnant.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# Allow importing modules from the backend package
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from question_analyzer import TraditionalHoraryQuestionAnalyzer
+import pytest
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Is she pregnant?",
+        "Is he lying?",
+        "Is they happy?",
+    ],
+)
+def test_direct_pronoun_detection(question):
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    result = analyzer.analyze_question(question)
+    assert result["third_person_analysis"]["is_third_person"] is True


### PR DESCRIPTION
## Summary
- Switch third-person detection to regex word-boundary patterns
- Add direct pronoun checks for "is he", "is she", and "is they"
- Cover new pronouns with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e0b257c2083249cd7b96c2a8c54e2