### PR TITLE
Handle third-person pregnancy questions

### DIFF
--- a/backend/question_analyzer.py
+++ b/backend/question_analyzer.py
@@ -398,7 +398,12 @@ class TraditionalHoraryQuestionAnalyzer:
             houses.extend([1, 7])  # L1 = self, L7 = other person/partner
             
         elif question_type == "pregnancy":
-            houses.append(5)  # Pregnancy and children
+            if third_person_analysis and third_person_analysis.get("is_third_person"):
+                subject_house = third_person_analysis["subject_house"]
+                pregnancy_house = self._apply_house_derivation(subject_house, 5)
+                houses.extend([subject_house, pregnancy_house])
+            else:
+                houses.append(5)  # Pregnancy and children
             
         elif question_type == "children":
             houses.append(5)  # Children
@@ -534,13 +539,26 @@ class TraditionalHoraryQuestionAnalyzer:
                 significators = {
                     "querent_house": 1,  # Teacher (querent)
                     "student_house": houses[1] if len(houses) > 1 else 7,  # Student (7th house)
-                    "preparation_house": houses[2] if len(houses) > 2 else 9,  # Student's prep (9th house)  
+                    "preparation_house": houses[2] if len(houses) > 2 else 9,  # Student's prep (9th house)
                     "success_house": houses[3] if len(houses) > 3 else 10,  # Success (10th house)
                     "quesited_house": houses[3] if len(houses) > 3 else 10,  # Primary question = success
                     "moon_role": "translation of light between significators",
                     "special_significators": {},
                     "transaction_type": False,
                     "third_person_education": True
+                }
+            elif third_person_analysis and third_person_analysis.get("is_third_person") and question_type == "pregnancy":
+                subject_house = houses[1] if len(houses) > 1 else third_person_analysis.get("subject_house", 7)
+                pregnancy_house = houses[2] if len(houses) > 2 else self._apply_house_derivation(subject_house, 5)
+                significators = {
+                    "querent_house": 1,
+                    "subject_house": subject_house,
+                    "pregnancy_house": pregnancy_house,
+                    "quesited_house": pregnancy_house,
+                    "moon_role": "co-significator of querent and general flow",
+                    "special_significators": {},
+                    "transaction_type": False,
+                    "third_person_pregnancy": True
                 }
             else:
                 # FIXED: For general questions, use 7th house. For derived house questions, use the actual target.

--- a/backend/tests/test_is_she_pregnant.py
+++ b/backend/tests/test_is_she_pregnant.py
@@ -20,3 +20,10 @@ def test_direct_pronoun_detection(question):
     analyzer = TraditionalHoraryQuestionAnalyzer()
     result = analyzer.analyze_question(question)
     assert result["third_person_analysis"]["is_third_person"] is True
+
+
+def test_pregnancy_house_derivation():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    result = analyzer.analyze_question("Is she pregnant?")
+    assert result["relevant_houses"] == [1, 7, 11]
+    assert result["significators"]["quesited_house"] == 11


### PR DESCRIPTION
## Summary
- Allow pregnancy questions about someone else to derive the subject's fifth house
- Return derived pregnancy house as quesited house and include subject in significators
- Test pregnancy house derivation for third-person pronoun questions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0e03db28832492ca21dcb87291b6